### PR TITLE
[Build] Fix node sass unsupported runtime error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
             - SYS_NICE
 
     node:
-        image: node:current-buster-slim
+        image: node:14-buster-slim
         container_name: node_vesoul-edition
         command: "yarn run watch"
         restart: unless-stopped


### PR DESCRIPTION
    Switch to Node "current-buster-slim" docker image gave the error :

        "Node Sass does not yet support your current environment: Linux
        64-bit with Unsupported runtime (88)"

    https://github.com/sass/node-sass/releases/tag/v4.14.1 list
    supported runtime. Node v14* is supported so node:current-buster-slim image
    is replaced by node:14-buster-slim.